### PR TITLE
It seems like the config file needs to be written for the createBuilder to run:

### DIFF
--- a/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
+++ b/src/main/java/io/fabric8/maven/docker/service/BuildXService.java
@@ -64,10 +64,10 @@ public class BuildXService {
         Path configPath = getDockerStateDir(imageConfig.getBuildConfiguration(),  buildDirs);
         List<String> buildX = Arrays.asList("docker", "--config", configPath.toString(), "buildx");
 
-        String builderName = createBuilder(configPath, buildX, imageConfig, buildDirs);
         Path configJson = configPath.resolve("config.json");
         try {
             createConfigJson(configJson, authConfig);
+            String builderName = createBuilder(configPath, buildX, imageConfig, buildDirs);
             builder.useBuilder(buildX, builderName, buildDirs, imageConfig,  configuredRegistry, context);
         } finally {
             removeConfigJson(configJson);


### PR DESCRIPTION
at least my docker fails if the config file doesn't exist
